### PR TITLE
Require Sign In UI

### DIFF
--- a/app/src/components/Articles/Buttons/LikeButton.js
+++ b/app/src/components/Articles/Buttons/LikeButton.js
@@ -4,6 +4,7 @@ import { toggleLikeByArticleID } from '../../../utils/functions/articles';
 import { withFirebase } from '../../../utils/firebase';
 import { withRouter } from 'react-router-dom';
 import { compose } from 'recompose';
+import ForceSignInModal from '../../Auth/ForceSignInModal';
 
 import IconButton from '@material-ui/core/IconButton';
 import FavoriteBorderIcon from '@material-ui/icons/FavoriteBorder';
@@ -14,10 +15,12 @@ class LikeButton extends React.Component {
         super(props);
         this.state = {
             liked: false,
-            numLikes: this.props.liked_users.length
+            numLikes: this.props.liked_users.length,
+            signInModal: false
         }
         this.toggleLike = this.toggleLike.bind(this);
         this.handleClick = this.handleClick.bind(this);
+        this.handleCloseModal = this.handleCloseModal.bind(this);
     }
 
     componentDidMount() {
@@ -36,8 +39,17 @@ class LikeButton extends React.Component {
         }
         else {
             const { history } = this.props;
-            history.push('/signin');
+            // history.push('/signin');
+            this.setState({
+                signInModal: true
+            });
         }
+    }
+
+    handleCloseModal() {
+        this.setState({
+            signInModal: false
+        });
     }
 
     toggleLike() {
@@ -61,14 +73,17 @@ class LikeButton extends React.Component {
 
     render() {
         return (
-            <IconButton aria-label="Like" onClick={this.handleClick}>
-                {this.state.liked ? (
-                    <FavoriteIcon></FavoriteIcon>
-                ) : (
-                        <FavoriteBorderIcon></FavoriteBorderIcon>
-                    )}
-                {this.state.numLikes}
-            </IconButton>
+            <div className="Like Button Wrapper">
+                <IconButton aria-label="Like" onClick={this.handleClick}>
+                    {this.state.liked ? (
+                        <FavoriteIcon></FavoriteIcon>
+                    ) : (
+                            <FavoriteBorderIcon></FavoriteBorderIcon>
+                        )}
+                    {this.state.numLikes}
+                </IconButton>
+                <ForceSignInModal isOpen={this.state.signInModal} closeModal={this.handleCloseModal} />
+            </div>
         )
     }
 

--- a/app/src/components/Articles/Buttons/LikeButton.js
+++ b/app/src/components/Articles/Buttons/LikeButton.js
@@ -82,7 +82,11 @@ class LikeButton extends React.Component {
                         )}
                     {this.state.numLikes}
                 </IconButton>
-                <ForceSignInModal isOpen={this.state.signInModal} closeModal={this.handleCloseModal} />
+                <ForceSignInModal
+                    isOpen={this.state.signInModal}
+                    closeModal={this.handleCloseModal}
+                    accessing={"liking articles"}
+                />
             </div>
         )
     }

--- a/app/src/components/Auth/ForceSignInModal.js
+++ b/app/src/components/Auth/ForceSignInModal.js
@@ -37,7 +37,7 @@ export default function ForceSignInModal(props) {
             <DialogTitle id="alert-dialog-title">Sign In Required</DialogTitle>
             <DialogContent>
                 <DialogContentText id="alert-dialog-description">
-                    You must be logged in to access {props.accessing ? props.accessing : "this functionality"}. Please log in or go back.
+                    You must be logged in to access {props.accessing ? props.accessing : "this functionality"}. Please log in {props.accessPage ? "or go back to another page" : "or go back to the page"}.
           </DialogContentText>
             </DialogContent>
             <DialogActions>

--- a/app/src/components/Auth/ForceSignInModal.js
+++ b/app/src/components/Auth/ForceSignInModal.js
@@ -1,0 +1,53 @@
+import React, { useState, useEffect } from 'react';
+
+import { useHistory } from "react-router-dom";
+
+import {
+    Button,
+    TextField,
+    Dialog,
+    DialogActions,
+    DialogContent,
+    DialogContentText,
+    DialogTitle
+} from '@material-ui/core';
+
+export default function ForceSignInModal(props) {
+    const history = useHistory();
+
+    const handleClose = () => {
+        props.closeModal();
+        if (props.accessPage) {
+            history.goBack();
+        }
+    };
+
+    const handleSignIn = () => {
+        props.closeModal();
+        history.push("/signin");
+    }
+
+    return (
+        <Dialog
+            open={props.isOpen}
+            onClose={handleClose}
+            aria-labelledby="alert-dialog-title"
+            aria-describedby="alert-dialog-description"
+        >
+            <DialogTitle id="alert-dialog-title">Sign In Required</DialogTitle>
+            <DialogContent>
+                <DialogContentText id="alert-dialog-description">
+                    You must be logged in to access {props.accessing ? props.accessing : "this functionality"}. Please log in or go back.
+          </DialogContentText>
+            </DialogContent>
+            <DialogActions>
+                <Button onClick={handleSignIn} color="primary">
+                    Sign In
+          </Button>
+                <Button onClick={handleClose} color="primary" autoFocus>
+                    Go Back
+          </Button>
+            </DialogActions>
+        </Dialog>
+    );
+}

--- a/app/src/components/Auth/ForceSignInModal.js
+++ b/app/src/components/Auth/ForceSignInModal.js
@@ -16,14 +16,15 @@ export default function ForceSignInModal(props) {
     const history = useHistory();
 
     const handleClose = () => {
-        props.closeModal();
         if (props.accessPage) {
             history.goBack();
+        }
+        else {
+            props.closeModal();
         }
     };
 
     const handleSignIn = () => {
-        props.closeModal();
         history.push("/signin");
     }
 

--- a/app/src/utils/session/withAuthorization.js
+++ b/app/src/utils/session/withAuthorization.js
@@ -5,14 +5,24 @@ import { compose } from 'recompose';
 import AuthUserContext from './context';
 import { withFirebase } from '../firebase';
 
+import ForceSignInModal from '../../components/Auth/ForceSignInModal';
+
 const withAuthorization = condition => Component => {
     class WithAuthorization extends React.Component {
+        constructor(props) {
+            super(props);
+            this.state = {
+                openModal: false,
+            }
+            this.handleCloseModal = this.handleCloseModal.bind(this);
+        }
         componentDidMount() {
             this.listener = this.props.firebase.auth.onAuthStateChanged(
                 authUser => {
                     if (!condition(authUser)) {
-                        this.props.history.push('/signin');
-                        // TODO: figure out how to launch an error saying that you need to be signed in
+                        this.setState({
+                            openModal: true
+                        });
                     }
                 },
             );
@@ -22,11 +32,24 @@ const withAuthorization = condition => Component => {
             this.listener();
         }
 
+        handleCloseModal() {
+            this.setState({
+                openModal: false
+            });
+        }
+
         render() {
             return (
                 <AuthUserContext.Consumer>
                     {authUser =>
-                        condition(authUser) ? <Component {...this.props} user={authUser} /> : null
+                        condition(authUser) ?
+                            <Component {...this.props} user={authUser} />
+                            :
+                            <ForceSignInModal
+                                isOpen={this.state.openModal}
+                                accessPage
+                                closeModal={this.handleCloseModal}
+                            />
                     }
                 </AuthUserContext.Consumer>
             );


### PR DESCRIPTION
Requiring a sign in now prompts a modal that asks you to either login or go back. Handles a page reauthorization and a component unauthorization different